### PR TITLE
Support for the Python Language Server

### DIFF
--- a/internal/lsp/acmelsp/client.go
+++ b/internal/lsp/acmelsp/client.go
@@ -36,6 +36,11 @@ func (h *clientHandler) ShowMessage(ctx context.Context, params *protocol.ShowMe
 	return nil
 }
 
+func (h *clientHandler) ShowStatus(ctx context.Context, params *protocol.ShowStatusParams) (*protocol.MessageActionItem, error) {
+	log.Printf("LSP %v: %v\n", params.Type, params.Message)
+	return nil, nil
+}
+
 func (h *clientHandler) LogMessage(ctx context.Context, params *protocol.LogMessageParams) error {
 	if h.cfg.Logger != nil {
 		h.cfg.Logger.Printf("%v: %v\n", params.Type, params.Message)

--- a/internal/lsp/protocol/tsprotocol.go
+++ b/internal/lsp/protocol/tsprotocol.go
@@ -1361,6 +1361,31 @@ type ShowMessageRequestParams struct {
 	Actions []MessageActionItem `json:"actions,omitempty"`
 }
 
+type ShowStatusParams struct {
+
+	/*Type defined:
+	 * The message type. See {@link MessageType}
+	 */
+	Type MessageType `json:"type"`
+
+	/*Message defined:
+	 * The actual message
+	 */
+	Message string `json:"message"`
+
+	/*Message defined:
+	 * The actual message
+	 */
+	ShortMessage string `json:"shortMessage"`
+
+	/*Actions defined:
+	 * The message action items to present.
+	 */
+	Actions []MessageActionItem `json:"actions,omitempty"`
+}
+
+
+
 /*LogMessageParams defined:
  * The log message parameters.
  */

--- a/internal/lsp/protocol/tsserver.go
+++ b/internal/lsp/protocol/tsserver.go
@@ -521,7 +521,6 @@ func (h serverHandler) Deliver(ctx context.Context, r *jsonrpc2.Request, deliver
 			log.Error(ctx, "", err)
 		}
 		return true
-
 	default:
 		return false
 	}

--- a/internal/lsp/proxy/client.go
+++ b/internal/lsp/proxy/client.go
@@ -26,6 +26,10 @@ func (c *lspClientDispatcher) ShowMessage(context.Context, *protocol.ShowMessage
 	return fmt.Errorf("ShowMessage not implemented")
 }
 
+func (c *lspClientDispatcher) ShowStatus(context.Context, *protocol.ShowStatusParams)  (*protocol.MessageActionItem,error) {
+	return nil, fmt.Errorf("ShowStatus not implemented")
+}
+
 func (c *lspClientDispatcher) LogMessage(ctx context.Context, params *protocol.LogMessageParams) error {
 	if Debug {
 		log.Printf("log: proxy %v: %v\n", params.Type, params.Message)


### PR DESCRIPTION
PYLS has two quirks: first, it requires that window/showStatus is implemented; second, on formatting it replaces the full text, which causes a bad user experience in acme. 

This PR addresses both of these by (1) implementing window/showStatus, and (2) breaking up full-replacement texts into a patch that in turn is converted into fine-grained text edit commands.