### PR TITLE
Fix completion, code formatting, and hover help for dartls

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,3 +9,5 @@ require (
 	github.com/google/go-cmp v0.3.0
 	github.com/sourcegraph/jsonrpc2 v0.2.0
 )
+
+replace 9fans.net/internal/go-lsp => ../go-lsp-internal

--- a/internal/lsp/acmelsp/acmelsp.go
+++ b/internal/lsp/acmelsp/acmelsp.go
@@ -157,7 +157,7 @@ func CodeActionAndFormat(ctx context.Context, server FormatServer, doc *protocol
 			TextDocument: *doc,
 			Range:        protocol.Range{},
 			Context: protocol.CodeActionContext{
-				Diagnostics: nil,
+				Diagnostics: []protocol.Diagnostic{},
 				Only:        actions,
 			},
 		})


### PR DESCRIPTION
The Dart LSP insists on getting the invocation kind for completions, and on the diagnostics for the "Format" code action to be empty, but _not_ `null`.

Dart's LS sends hover help responses as the deprecated protocol.MarkedString instead of protocol.MarkupContent.

This requires [a tweak to the generated LSP protocol code](https://github.com/9fans/go-lsp-internal/pull/4) as well, so it should probably be merged after the generated code has been updated and the `replace` override in `go.mod` has been removed.