### PR TITLE
Add "IgnorePattern" to file name handlers to explicitly ignore some paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ CodeActionsOnPut = ["source.organizeImports"]
 
 [[FilenameHandlers]]
   Pattern = "\\.go$"
+  # Don't run this LSP in files in /projects/example (for instance because that
+  # project needs a gopls with a Bazel packages driver).
+  Ignore = "/projects/example"
   LanguageID = "go"
   ServerKey = "gopls"
 ```

--- a/internal/lsp/acmelsp/acmelsp_test.go
+++ b/internal/lsp/acmelsp/acmelsp_test.go
@@ -78,7 +78,7 @@ func TestParseFlagSet(t *testing.T) {
 					Server: &config.Server{
 						Command: []string{"gopls", "-rpc.trace"},
 					},
-					Re: regexp.MustCompile(`\.go$`),
+					Pattern: regexp.MustCompile(`\.go$`),
 				},
 			},
 			nil,
@@ -93,7 +93,7 @@ func TestParseFlagSet(t *testing.T) {
 					Server: &config.Server{
 						Address: "localhost:4389",
 					},
-					Re: regexp.MustCompile(`\.go$`),
+					Pattern: regexp.MustCompile(`\.go$`),
 				},
 			},
 			nil,
@@ -146,7 +146,7 @@ func TestParseFlagSet(t *testing.T) {
 				}
 				got := tc.serverInfo[0]
 				want := ss.Data[0]
-				if got, want := got.Re.String(), want.Re.String(); got != want {
+				if got, want := got.Pattern.String(), want.Pattern.String(); got != want {
 					t.Errorf("filename pattern for %v is %v; want %v", got, tc.args, want)
 				}
 				if got, want := got.Command, want.Command; !cmp.Equal(got, want) {

--- a/internal/lsp/acmelsp/client.go
+++ b/internal/lsp/acmelsp/client.go
@@ -34,7 +34,11 @@ type clientHandler struct {
 }
 
 func (h *clientHandler) ShowMessage(ctx context.Context, params *protocol.ShowMessageParams) error {
-	log.Printf("LSP %v: %v\n", params.Type, params.Message)
+	if h.cfg != nil && h.cfg.FilenameHandler != nil {
+		log.Printf("LSP %s %v: %v\n", h.cfg.FilenameHandler.ServerKey, params.Type, params.Message)
+	} else {
+		log.Printf("LSP %v: %v\n", params.Type, params.Message)
+	}
 	return nil
 }
 

--- a/internal/lsp/acmelsp/config/config.go
+++ b/internal/lsp/acmelsp/config/config.go
@@ -109,6 +109,9 @@ type FilenameHandler struct {
 	// Pattern is a regular expression that matches filename.
 	Pattern string
 
+	// Ignore is a regular expression that matches file names not to run this LSP for, even if Pattern matches.
+	Ignore string
+
 	// Language identifier (e.g. "go" or "python")
 	// See list of languages here:
 	// https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocumentItem

--- a/internal/lsp/acmelsp/exec.go
+++ b/internal/lsp/acmelsp/exec.go
@@ -123,9 +123,11 @@ type ServerInfo struct {
 	*config.Server
 	*config.FilenameHandler
 
-	Re     *regexp.Regexp // filename regular expression
-	Logger *log.Logger    // Logger for config.Server.LogFile
-	srv    *Server        // running server instance
+	Pattern *regexp.Regexp // filename regular expression
+	Ignore  *regexp.Regexp
+
+	Logger *log.Logger // Logger for config.Server.LogFile
+	srv    *Server     // running server instance
 }
 
 func (info *ServerInfo) start(cfg *ClientConfig) (*Server, error) {
@@ -181,10 +183,20 @@ func NewServerSet(cfg *config.Config, diagWriter DiagnosticsWriter) (*ServerSet,
 		if len(cs.Command) == 0 && len(cs.Address) == 0 {
 			return nil, fmt.Errorf("invalid server for key %q", h.ServerKey)
 		}
+
 		re, err := regexp.Compile(h.Pattern)
 		if err != nil {
 			return nil, err
 		}
+
+		var ignore *regexp.Regexp
+		if h.Ignore != "" {
+			ignore, err = regexp.Compile(h.Ignore)
+			if err != nil {
+				return nil, fmt.Errorf("compiling \"Ignore\" pattern: %w", err)
+			}
+		}
+
 		var logger *log.Logger
 		if cs.LogFile != "" {
 			f, err := os.Create(cs.LogFile)
@@ -196,7 +208,8 @@ func NewServerSet(cfg *config.Config, diagWriter DiagnosticsWriter) (*ServerSet,
 		data = append(data, &ServerInfo{
 			Server:          cs,
 			FilenameHandler: &cfg.FilenameHandlers[i],
-			Re:              re,
+			Pattern:         re,
+			Ignore:          ignore,
 			Logger:          logger,
 		})
 	}
@@ -223,7 +236,11 @@ func (ss *ServerSet) FindServerWithCapability(match func(*protocol.InitializeRes
 
 func (ss *ServerSet) MatchFile(filename string) *ServerInfo {
 	for _, info := range ss.Data {
-		if info.Re.MatchString(filename) {
+		if info.Ignore != nil && info.Ignore.MatchString(filename) {
+			continue
+		}
+
+		if info.Pattern.MatchString(filename) {
 			return info
 		}
 	}
@@ -272,9 +289,9 @@ func (ss *ServerSet) CloseAll() {
 func (ss *ServerSet) PrintTo(w io.Writer) {
 	for _, info := range ss.Data {
 		if len(info.Address) > 0 {
-			fmt.Fprintf(w, "%v %v\n", info.Re, info.Address)
+			fmt.Fprintf(w, "%v %v %v\n", info.Pattern, info.Ignore, info.Address)
 		} else {
-			fmt.Fprintf(w, "%v %v\n", info.Re, strings.Join(info.Command, " "))
+			fmt.Fprintf(w, "%v %v %v\n", info.Pattern, info.Ignore, strings.Join(info.Command, " "))
 		}
 	}
 }


### PR DESCRIPTION
Some setups require running the same language server with slightly different configurations for different paths. One example would be "I need `gopls` with the Bazel package driver for exactly one project, but I want a regular `gopls` for all other Go files".

This is a bit cumbersome to express with just the positive match pattern, so this adds an explicit "ignore all files that match this pattern, even if they match `Pattern`" option to `FilenameHandlers`.