### PR TITLE
Initialize non-nullable slices in RPC parameters

### DIFF
--- a/cmd/L/main.go
+++ b/cmd/L/main.go
@@ -167,7 +167,8 @@ func run(cfg *config.Config, args []string) error {
 		}
 		return server.DidChangeWorkspaceFolders(ctx, &protocol.DidChangeWorkspaceFoldersParams{
 			Event: protocol.WorkspaceFoldersChangeEvent{
-				Added: dirs,
+				Added:   dirs,
+				Removed: []protocol.WorkspaceFolder{},
 			},
 		})
 	case "ws-":
@@ -178,6 +179,7 @@ func run(cfg *config.Config, args []string) error {
 		return server.DidChangeWorkspaceFolders(ctx, &protocol.DidChangeWorkspaceFoldersParams{
 			Event: protocol.WorkspaceFoldersChangeEvent{
 				Removed: dirs,
+				Added:   []protocol.WorkspaceFolder{},
 			},
 		})
 	case "win", "assist": // "win" is deprecated

--- a/internal/lsp/acmelsp/acmelsp.go
+++ b/internal/lsp/acmelsp/acmelsp.go
@@ -157,7 +157,7 @@ func CodeActionAndFormat(ctx context.Context, server FormatServer, doc *protocol
 			TextDocument: *doc,
 			Range:        protocol.Range{},
 			Context: protocol.CodeActionContext{
-				Diagnostics: nil,
+				Diagnostics: []protocol.Diagnostic{},
 				Only:        actions,
 			},
 		})


### PR DESCRIPTION
Initialize both the added and removed slices in Lws+ and Lws-. The json package serializes uninitialized slices as `null` instead of `[]`, however the Language Server specification defines `WorkspaceFolderChangeEvent` fields `added` and `removed` as non-nullable `[]WorkspaceFolder`. Language servers like jdtls fail when encountering null in either added or removed JSON RPC messages, this change enables using the [jdtls](https://github.com/eclipse-jdtls/eclipse.jdt.ls) langauge server implementation.