### PR TITLE
L sym [-p] pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,14 @@ We aim to support any servers that follow the LSP protocol.
 Following is a compatibility table between LSP servers and the
 [L sub-commands](https://pkg.go.dev/9fans.net/acme-lsp/cmd/L):
 
-|                       |  fmt  |  def  | refs  | type  |  sig   |  hov  | impls | comp   | syms  |  rn   |
-| :-------------------- | :---: | :---: | :---: | :---: | :----: | :---: | :---: | :----: | :---: | :---: |
-| [clangd][]            |  ✅   |  ✅   |  ✅   |  ✅   |  ✅    |  ✅   |  ✅   |  ✅    |  ✅   |  ✅   |
-| [dart][dart-lsp]      |  ✅   |  ✅   |  ✅   |  ✅   |  ✅    |  ✅   |  ✅   |  ✅    |  ✅   |  ✅   |
-| [gopls][]             |  ✅   |  ✅   |  ✅   |  ✅   |  ✅    |  ✅   |  ✅   |  ✅    |  ✅   |  ✅   |
-| [rust][rust-analyzer] |  ✅   |  ✅   |  ✅   |  ✅   |  ✅    |  ✅   |  ✅   |  ✅    |  ✅   |  ✅   |
-| [ty][astral-ty]       |   -   |  ✅   |  ✅   |  ✅   |  ✅    |  ✅   |  -    |  ✅    |  ✅   |  ✅   |
-| [typescript][ts-lsp]  |  ✅   |  ✅   |  ✅   |  ✅   |  ✅    |  ✅   |  ✅   |  ✅    |  ✅   |  ✅   |
+|                       |  fmt  |  def  | refs  | type  |  sig   |  hov  | impls | comp   | syms  |  rn   | wss |
+| :-------------------- | :---: | :---: | :---: | :---: | :----: | :---: | :---: | :----: | :---: | :---: | :-: |
+| [clangd][]            |  ✅   |  ✅   |  ✅   |  ✅   |  ✅    |  ✅   |  ✅   |  ✅    |  ✅   |  ✅   | ✅  |
+| [dart][dart-lsp]      |  ✅   |  ✅   |  ✅   |  ✅   |  ✅    |  ✅   |  ✅   |  ✅    |  ✅   |  ✅   | ✅  |
+| [gopls][]             |  ✅   |  ✅   |  ✅   |  ✅   |  ✅    |  ✅   |  ✅   |  ✅    |  ✅   |  ✅   | ✅  |
+| [rust][rust-analyzer] |  ✅   |  ✅   |  ✅   |  ✅   |  ✅    |  ✅   |  ✅   |  ✅    |  ✅   |  ✅   | ✅  |
+| [ty][astral-ty]       |   -   |  ✅   |  ✅   |  ✅   |  ✅    |  ✅   |  -    |  ✅    |  ✅   |  ✅   | ✅  |
+| [typescript][ts-lsp]  |  ✅   |  ✅   |  ✅   |  ✅   |  ✅    |  ✅   |  ✅   |  ✅    |  ✅   |  ✅   | ✅  |
 
 [clangd]: https://clangd.llvm.org/
 [dart-lsp]: https://github.com/dart-lang/sdk/blob/main/pkg/analysis_server/tool/lsp_spec/README.md

--- a/cmd/L/doc.go
+++ b/cmd/L/doc.go
@@ -15,10 +15,13 @@ attempt to find the focused window ID by connecting to acmefocused
 
 List of sub-commands:
 
-		comp [-e]
+		comp [-e] [-E]
 			Print candidate completions at the cursor position. If
 			-e (edit) flag is given and there is only one candidate,
-			the completion is applied instead of being printed.
+			the completion is applied instead of being printed. If
+			-E (Edit) flag is given, the first matching candidate is
+			applied, and all matches will be displayed in a dedicated
+			Acme window named /LSP/Completions.
 
 		def [-p]
 			Find where the symbol at the cursor position is defined
@@ -74,10 +77,15 @@ List of sub-commands:
 			Remove given directories to the set of workspace directories.
 			Current working directory is removed if no directory is specified.
 
+		wss query
+			Print workspace symbols matching the query string.
+
 	  -acme.addr string
 	    	address where acme is serving 9P file system (default "/tmp/ns.fhs.:0/acme")
 	  -acme.net string
 	    	network where acme is serving 9P file system (default "unix")
+	  -headless
+	    	Run without acme (for testing)
 	  -proxy.addr string
 	    	address used for communication between acme-lsp and L (default "/tmp/ns.fhs.:0/acme-lsp.rpc")
 	  -proxy.net string

--- a/cmd/L/main.go
+++ b/cmd/L/main.go
@@ -98,6 +98,9 @@ List of sub-commands:
 	ws- [directories...]
 		Remove given directories to the set of workspace directories.
 		Current working directory is removed if no directory is specified.
+
+	wss query
+		Print workspace symbols matching the query string.
 `
 
 func usage() {
@@ -193,6 +196,12 @@ func run(cfg *config.Config, args []string) error {
 			return acmelsp.Assist(sm, args[0])
 		}
 		return fmt.Errorf("unknown assist command %q", args[0])
+	case "wss":
+		args = args[1:]
+		if len(args) == 0 {
+			return fmt.Errorf("missing query")
+		}
+		return acmelsp.Symbol(server, args[0])
 	}
 
 	win, err := acmelsp.OpenFocusedWin(cfg.Headless)

--- a/cmd/L/testdata/clangd.txt
+++ b/cmd/L/testdata/clangd.txt
@@ -58,6 +58,10 @@ stdout 'main int \(\)'
 stdout 'hello void \(std::string\)'
 stdout '/hello\.cpp:'
 
+# Query workspace symbols
+L -headless wss WorldGreeter
+stdout 'hello\.cpp:.*:class WorldGreeter : public Greeter {'
+
 # Rename Greeter to BaseGreeter
 env acmeaddr=$WORK/hello.cpp:'#48'
 L -headless rn BaseGreeter

--- a/cmd/L/testdata/dart.txt
+++ b/cmd/L/testdata/dart.txt
@@ -57,6 +57,10 @@ stdout 'main \(\)'
 stdout '/hello\.dart:'
 stdout 'hello \(String name\)'
 
+# Query workspace symbols
+L -headless wss WorldGreeter
+stdout 'hello\.dart:.*:class WorldGreeter implements Greeter {'
+
 # Rename WorldGreeter to EarthGreeter
 env acmeaddr=$WORK/hello.dart:'#66'
 L -headless rn EarthGreeter

--- a/cmd/L/testdata/gopls.txt
+++ b/cmd/L/testdata/gopls.txt
@@ -55,6 +55,11 @@ stdout '\(HelloGreeter\).Hello func()'
 stdout 'main func\(\)'
 stdout '/hello\.go:'
 
+# Query workspace symbols
+L -headless wss HelloGreeter
+stdout 'hello\.go:.*:type HelloGreeter struct{}'
+stdout 'hello\.go:.*:func \(g HelloGreeter\) Hello\(\) {'
+
 # Rename HelloGreeter to WorldGreeter
 env acmeaddr=$WORK/hello.go:'#202'
 L -headless rn WorldGreeter

--- a/cmd/L/testdata/rust.txt
+++ b/cmd/L/testdata/rust.txt
@@ -63,6 +63,10 @@ stdout 'impl Greeter for HelloGreeter'
 stdout 'main fn\(\)'
 stdout '/src/main.rs:'
 
+# Query workspace symbols
+L -headless wss HelloGreeter
+stdout 'src/main\.rs:.*:struct HelloGreeter;'
+
 # Rename HelloGreeter to WorldGreeter
 env acmeaddr=$WORK/src/main.rs:'#223'
 L -headless rn WorldGreeter

--- a/cmd/L/testdata/ts.txt
+++ b/cmd/L/testdata/ts.txt
@@ -53,6 +53,10 @@ stdout 'HelloGreeter'
 stdout 'main'
 stdout '/hello.ts:'
 
+# Query workspace symbols
+L -headless wss HelloGreeter
+stdout 'hello\.ts:.*:class HelloGreeter implements Greeter {'
+
 # Rename HelloGreeter class to WorldGreeter
 env acmeaddr=$WORK/hello.ts:'#168'
 L -headless rn WorldGreeter

--- a/cmd/L/testdata/ty.txt
+++ b/cmd/L/testdata/ty.txt
@@ -45,6 +45,10 @@ stdout 'hello'
 stdout 'main'
 stdout '/hello.py:'
 
+# Query workspace symbols
+L -headless wss Greeter
+stdout 'hello\.py:.*:class Greeter:'
+
 # Rename Greeter to WorldGreeter
 env acmeaddr=$WORK/hello.py:'#131'
 L -headless rn WorldGreeter

--- a/internal/lsp/acmelsp/assist.go
+++ b/internal/lsp/acmelsp/assist.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
+	"os"
 	"time"
 	"unicode"
 
@@ -291,6 +292,18 @@ loop:
 		}
 	}
 	return nil
+}
+
+func Symbol(server proxy.Server, query string) error {
+	symbols, err := server.Symbol(context.Background(), &protocol.WorkspaceSymbolParams{Query: query})
+	if err != nil {
+		return err
+	}
+	var locations []protocol.Location
+	for _, symbol := range symbols {
+		locations = append(locations, symbol.Location)
+	}
+	return PrintLocations(os.Stdout, locations)
 }
 
 // ServerMatcher represents a set of servers where it's possible to

--- a/internal/lsp/acmelsp/exec.go
+++ b/internal/lsp/acmelsp/exec.go
@@ -266,7 +266,7 @@ func (ss *ServerSet) PrintTo(w io.Writer) {
 	}
 }
 
-func (ss *ServerSet) forEach(f func(*Client) error) error {
+func (ss *ServerSet) ForEach(f func(*Client) error) error {
 	for _, info := range ss.Data {
 		srv, err := info.start(ss.ClientConfig(info))
 		if err != nil {
@@ -294,7 +294,7 @@ func (ss *ServerSet) Workspaces() []protocol.WorkspaceFolder {
 
 // DidChangeWorkspaceFolders adds and removes given workspace folders.
 func (ss *ServerSet) DidChangeWorkspaceFolders(ctx context.Context, added, removed []protocol.WorkspaceFolder) error {
-	err := ss.forEach(func(c *Client) error {
+	err := ss.ForEach(func(c *Client) error {
 		return c.DidChangeWorkspaceFolders(ctx, &protocol.DidChangeWorkspaceFoldersParams{
 			Event: protocol.WorkspaceFoldersChangeEvent{
 				Added:   added,

--- a/internal/lsp/acmelsp/proxy.go
+++ b/internal/lsp/acmelsp/proxy.go
@@ -144,6 +144,19 @@ func (s *proxyServer) DocumentSymbol(ctx context.Context, params *protocol.Docum
 	return srv.Client.DocumentSymbol(ctx, params)
 }
 
+func (s *proxyServer) Symbol(ctx context.Context, params *protocol.WorkspaceSymbolParams) ([]protocol.SymbolInformation, error) {
+	var symbols []protocol.SymbolInformation
+	err := s.ss.ForEach(func(c *Client) error {
+		resp, err := c.Symbol(ctx, params)
+		if err != nil {
+			return err
+		}
+		symbols = append(symbols, resp...)
+		return nil
+	})
+	return symbols, err
+}
+
 func (s *proxyServer) TypeDefinition(ctx context.Context, params *protocol.TypeDefinitionParams) (*protocol.Or_Result_textDocument_typeDefinition, error) {
 	srv, err := serverForURI(s.ss, params.TextDocumentPositionParams.TextDocument.URI)
 	if err != nil {


### PR DESCRIPTION
Add the sym command which plumbs or prints results for a pattern as resolved by all configured LSPs. This enables functionality like search or resolution of symbols from plumber. 

Examples:
* Interactive search over all symbols of all projects, see [`Search`](https://github.com/cptaffe/acme-search)
* Plumber can match to java stack traces and plumb to the source file resolved by L sym and line in the stack trace. A better way to implement plumbing a stack trace line is described in #89.

Issues:
* Is plumbing all results a reasonable default? Perhaps `-p` should be implied.
* Slow language servers block the results of all others. In testing with `acme-search`, introducing [`metals`](https://scalameta.org/metals/) hung symbol results (and [`jdtls`](https://github.com/eclipse-jdtls/eclipse.jdt.ls) will until it fully initializes). Instead, results should stream.
  * Because this has to happen over an RPC boundary, a solution involving JSON RPC would need to be implemented.
  * Or, each upstream could be queried independently from `L` through the proxy server, and `L` can handle concurrently waiting on requests and printing results as they arrive.